### PR TITLE
Dpiスケーリング時、アイコンサイズを変更しないとアイコンプレビューの描画背景サイズがおかしくる問題を修正

### DIFF
--- a/ModernIconLib/UI/Preview/IconDrawSettingPanel.cs
+++ b/ModernIconLib/UI/Preview/IconDrawSettingPanel.cs
@@ -44,7 +44,7 @@ namespace ModernIconLib.UI.Preview
             if (DesignMode)
                 tableLayoutPanel1.Visible = true;
             updateSizeLabel();
-
+            trackBarSize_Scroll(this, null);
         }
 
         private void panelColorFill_MouseDown(object sender, MouseEventArgs e)


### PR DESCRIPTION
描画サイズは問題なく、プレビュー用のPictureBoxのサイズがdpiに応じて初期化されていないので修正する